### PR TITLE
fix: update exports in package.json for cjs compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,22 +13,26 @@
         "types": "./lib/index.d.ts"
       },
       "import": "./dist/native.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.cjs"
     },
     "./polyfill": {
       "node": {
         "require": "./dist/polyfill.cjs",
         "import": "./dist/polyfill.mjs"
       },
-      "import": "./lib/empty.mjs"
+      "import": "./lib/empty.mjs",
+      "default": "./dist/polyfill.cjs"
     },
     "./node": {
       "require": "./dist/node.cjs",
-      "import": "./dist/node.mjs"
+      "import": "./dist/node.mjs",
+      "default": "./dist/node.cjs"
     },
     "./src/index.js": {
       "import": "./dist/index.mjs",
-      "types": "./lib/index.d.ts"
+      "types": "./lib/index.d.ts",
+      "default": "./dist/index.cjs"
     }
   },
   "main": "./lib/index.cjs",


### PR DESCRIPTION
The current `exports` in `package.json` is not compatible with pure CommonJS environments, trying to use the library results in:

```
Cannot find module 'node-fetch-native' from ...
```

In this change we add `default` to the different `exports` in order to properly support cjs.