### PR TITLE
feat: add warning for when node polyfill is used in non-node environments

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -3,6 +3,10 @@ import _fetch from "node-fetch";
 export { Blob, File, FormData, Headers, Request, Response } from "node-fetch";
 export { default as AbortController } from "abort-controller";
 
+if (!globalThis.process?.versions?.node && !globalThis.process?.env.DISABLE_NODE_FETCH_NATIVE_WARN) {
+  throw new Error("`node-fetch-native` with Node.js polyfills is being used in a non-Node.js environment. Please make sure you are using proper export conditions or report this issue to https://github.com/unjs/node-fetch-native . You can set `process.env.DISABLE_NODE_FETCH_NATIVE_WARN` to disable this warning.");
+}
+
 export const fetch = _fetch;
 export default fetch;
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`node-fetch-native` is intended to be used with proper export conditions otherwise a build with `node-fetch` polyfills will be used in non-Node.js environments like workers and can be silently happening too. 

This PR adds explicit warning to guide users:

> `node-fetch-native` with Node.js polyfills is being used in a non-Node.js environment. Please make sure you are using proper export conditions or report this issue to https://github.com/unjs/node-fetch-native . You can set `process.env.DISABLE_NODE_FETCH_NATIVE_WARN` to disable this warning.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
