### PR TITLE
build: add top level `react-native` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "types": "./lib/index.d.mts",
   "main": "./lib/index.cjs",
   "module": "./dist/index.mjs",
+  "react-native": "./dist/native.mjs",
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Should fix similar issues as #91 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

React Native seems to only respect the export defined as a root field inside package.json. See https://github.com/callstack/react-native-paper/blob/aebeabd8769988b17bb56b0f5673f252e1bda0d9/package.json#L7.

Tested on React Native 0.72.6 and Metro 0.76.8. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
