### PR TITLE
feat: http proxy util

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,96 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+https://github.com/node-fetch/node-fetch
+
+The MIT License (MIT)
+
+Copyright (c) 2016 - 2020 Node Fetch Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+https://github.com/mysticatea/abort-controller
+
+MIT License
+
+Copyright (c) 2017 Toru Nagashima
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+https://github.com/TooTallNate/proxy-agents
+
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+https://github.com/nodejs/undici
+
+MIT License
+
+Copyright (c) Matteo Collina and Undici contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,17 @@
 [![][npm-version-src]][npm-version-href]
 [![][github-actions-src]][github-actions-href]
 [![][packagephobia-src]][packagephobia-href]
+
 <!-- [![npm downloads][npm-downloads-src]][npm-downloads-href] -->
 <!-- [![Codecov][codecov-src]][codecov-href] -->
 
-A redistribution of [node-fetch v3](https://github.com/node-fetch/node-fetch) for better backward and forward compatibility.
+A redistribution of [node-fetch v3](https://github.com/node-fetch/node-fetch) (+ more!) for better backward and forward compatibility.
 
 **Why this package?**
 
 - We can no longer `require('node-fetch')` with latest version. This stopped popular libraries from upgrading and dependency conflicts between `node-fetch@2` and `node-fetch@3`.
 - With upcoming versions of Node.js, native `fetch` is being supported. We are prepared for native fetch support using this package yet keep supporting older Node versions.
+- With introduction of native fetch to Node.js via [undici](https://github.com/nodejs/undici) there is no easy way to support http proxies!
 
 **Features:**
 
@@ -24,6 +26,8 @@ A redistribution of [node-fetch v3](https://github.com/node-fetch/node-fetch) fo
 ✅ Use native version if imported without `node` condition using [conditional exports](https://nodejs.org/api/packages.html#packages_conditional_exports) with **zero bundle overhead**
 
 ✅ Polyfill support for Node.js
+
+✅ Compact and simple proxy supporting both Node.js versions without native fetch using [HTTP Agent](https://github.com/TooTallNate/proxy-agents/tree/main/packages/proxy-agent) and versions with native fetch using [Undici Proxy Agent](https://undici.nodejs.org/#/docs/api/ProxyAgent)
 
 ## Usage
 
@@ -44,21 +48,64 @@ You can now either import or require the dependency:
 
 ```js
 // ESM
-import fetch from 'node-fetch-native'
+import fetch from "node-fetch-native";
 
 // CommonJS
-const fetch = require('node-fetch-native')
+const fetch = require("node-fetch-native");
 ```
 
 More named exports:
 
 ```js
 // ESM
-import { fetch, Blob, FormData, Headers, Request, Response, AbortController } from 'node-fetch-native'
+import {
+  fetch,
+  Blob,
+  FormData,
+  Headers,
+  Request,
+  Response,
+  AbortController,
+} from "node-fetch-native";
 
 // CommonJS
-const { fetch, Blob, FormData, Headers, Request, Response, AbortController } = require('node-fetch-native')
+const {
+  fetch,
+  Blob,
+  FormData,
+  Headers,
+  Request,
+  Response,
+  AbortController,
+} = require("node-fetch-native");
 ```
+
+## Proxy support
+
+Currently Node.js has no standard way to support HTTP Proxies.
+
+This package exports a compact and simple proxy supporting both Node.js versions without native fetch using [HTTP Agent](https://github.com/TooTallNate/proxy-agents/tree/main/packages/proxy-agent) and versions with native fetch using [Undici Proxy Agent](https://undici.nodejs.org/#/docs/api/ProxyAgent).
+
+**Usage:**
+
+```ts
+import { fetch } from "node-fetch-native"; // or use global fetch
+import { createProxy } from "node-fetch-native/proxy";
+
+const proxy = createProxy(); // Uses HTTPS_PROXY or HTTP_PROXY by default
+
+const proxy = createProxy({ url: "http://localhost:8080" });
+
+await fetch("https://google.com", {
+  ...proxy,
+});
+```
+
+`createProxy` returns an object with `agent` (for older Node.js) and `dispatcher` keys (for newer Node.js)
+
+If no `url` option is provided, `HTTPS_PROXY` or `HTTP_PROXY` value will be used and if they also are not set, both `agent` and `dispatcher` values will be undefined.
+
+**Note:** Using export conditions, this utility works in Node.js and for other runtimes, it will simply return an stubed version as most of other runtimes now support http proxy out of the box!
 
 ## Force using non-native version
 
@@ -77,10 +124,10 @@ Using the polyfill method, we can once ensure global fetch is available in the e
 
 ```js
 // ESM
-import 'node-fetch-native/polyfill'
+import "node-fetch-native/polyfill";
 
 // CJS
-require('node-fetch-native/polyfill')
+require("node-fetch-native/polyfill");
 
 // You can now use fetch() without any import!
 ```
@@ -137,20 +184,16 @@ Made with 💛
 [node-fetch is published under the MIT license](https://github.com/node-fetch/node-fetch/blob/main/LICENSE.md)
 
 <!-- Badges -->
+
 [npm-version-src]: https://flat.badgen.net/npm/v/node-fetch-native
 [npm-version-href]: https://npmjs.com/package/node-fetch-native
-
 [npm-downloads-src]: https://flat.badgen.net/npm/dm/node-fetch-native
 [npm-downloads-href]: https://npmjs.com/package/node-fetch-native
-
 [github-actions-src]: https://flat.badgen.net/github/checks/unjs/node-fetch-native
 [github-actions-href]: https://github.com/unjs/node-fetch-native/actions?query=workflow%3Aci
-
 [packagephobia-src]: https://flat.badgen.net/packagephobia/install/node-fetch-native
 [packagephobia-href]: https://packagephobia.com/result?p=node-fetch-native
-
 [packagephobia-s-src]: https://flat.badgen.net/packagephobia/install/node-fetch-native?label=node-fetch-native&scale=.9
 [packagephobia-s-href]: https://packagephobia.com/result?p=node-fetch-native
-
 [packagephobia-s-alt-src]: https://flat.badgen.net/packagephobia/install/node-fetch?label=node-fetch&scale=.9
 [packagephobia-s-alt-href]: https://packagephobia.com/result?p=node-fetch

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ const {
 
 ## Proxy support
 
-Currently Node.js has no standard way to support HTTP Proxies.
+Node.js has no built-in support for HTTP Proxies for fetch ([see nodejs/undici#1650](https://github.com/nodejs/undici/issues/1650) and [nodejs/node#8381](https://github.com/nodejs/node/issues/8381))
 
-This package exports a compact and simple proxy supporting both Node.js versions without native fetch using [HTTP Agent](https://github.com/TooTallNate/proxy-agents/tree/main/packages/proxy-agent) and versions with native fetch using [Undici Proxy Agent](https://undici.nodejs.org/#/docs/api/ProxyAgent).
+This package bundles a compact and simple proxy supported for both Node.js versions without native fetch using [HTTP Agent](https://github.com/TooTallNate/proxy-agents/tree/main/packages/proxy-agent) and versions with native fetch using [Undici Proxy Agent](https://undici.nodejs.org/#/docs/api/ProxyAgent).
 
 **Usage:**
 
@@ -101,11 +101,11 @@ await fetch("https://google.com", {
 });
 ```
 
-`createProxy` returns an object with `agent` (for older Node.js) and `dispatcher` keys (for newer Node.js)
+`createProxy` returns an object with `agent` for older Node.js version and `dispatcher` keys for newer Node.js versions with undici and native fetch.
 
 If no `url` option is provided, `HTTPS_PROXY` or `HTTP_PROXY` value will be used and if they also are not set, both `agent` and `dispatcher` values will be undefined.
 
-**Note:** Using export conditions, this utility works in Node.js and for other runtimes, it will simply return an stubed version as most of other runtimes now support http proxy out of the box!
+**Note:** Using export conditions, this utility works in Node.js and for other runtimes, it will simply return an stubbed version as most of other runtimes now support http proxy out of the box!
 
 ## Force using non-native version
 

--- a/build.config.ts
+++ b/build.config.ts
@@ -1,3 +1,5 @@
+import { rm } from "node:fs/promises";
+import { resolve } from "node:path";
 import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig({
@@ -13,5 +15,18 @@ export default defineBuildConfig({
       keepNames: true,
     },
   },
-  entries: ["src/index", "src/native", "src/polyfill", "src/node"],
+  entries: [
+    "src/index",
+    "src/native",
+    "src/polyfill",
+    "src/node",
+    "src/proxy",
+    "src/proxy-stub",
+  ],
+  hooks: {
+    async "build:done"(ctx) {
+      // Save few bytes from dist...
+      await rm(resolve(ctx.options.outDir, "proxy.mjs"));
+    },
+  },
 });

--- a/lib/proxy.d.cts
+++ b/lib/proxy.d.cts
@@ -1,0 +1,8 @@
+import type * as http from "node:http";
+import type * as https from "node:https";
+import type * as undici from "undici";
+
+export declare const createProxy: (opts?: { url?: string }) => {
+  agent: http.Agent | https.Agent | undefined;
+  dispatcher: undici.Dispatcher | undefined;
+};

--- a/lib/proxy.d.mts
+++ b/lib/proxy.d.mts
@@ -1,0 +1,8 @@
+import type * as http from "node:http";
+import type * as https from "node:https";
+import type * as undici from "undici";
+
+export declare const createProxy: (opts?: { url?: string }) => {
+  agent: http.Agent | https.Agent | undefined;
+  dispatcher: undici.Dispatcher | undefined;
+};

--- a/package.json
+++ b/package.json
@@ -81,6 +81,10 @@
     },
     "./proxy": {
       "node": {
+        "import": {
+          "types": "./lib/proxy.d.mts",
+          "default": "./dist/proxy.cjs"
+        },
         "require": {
           "types": "./lib/proxy.d.cts",
           "default": "./dist/proxy.cjs"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,24 @@
         "types": "./lib/index.d.cts",
         "default": "./lib/index.cjs"
       }
+    },
+    "./proxy": {
+      "node": {
+        "require": {
+          "types": "./lib/proxy.d.cts",
+          "default": "./dist/proxy.cjs"
+        }
+      },
+      "default": {
+        "import": {
+          "types": "./lib/proxy.d.mts",
+          "default": "./dist/proxy-stub.mjs"
+        },
+        "require": {
+          "types": "./lib/proxy.d.cts",
+          "default": "./dist/proxy-stub.cjs"
+        }
+      }
     }
   },
   "main": "./lib/index.cjs",
@@ -100,15 +118,21 @@
     "test": "pnpm lint && pnpm build && vitest run --coverage"
   },
   "devDependencies": {
+    "@types/node": "^20.10.5",
     "@vitest/coverage-v8": "^1.1.0",
     "abort-controller": "^3.0.0",
+    "agent-base": "^7.1.0",
     "changelogen": "^0.5.5",
     "eslint": "^8.56.0",
     "eslint-config-unjs": "^0.2.1",
+    "http-proxy-agent": "^7.0.0",
+    "https-proxy-agent": "^7.0.2",
     "node-fetch": "^3.3.2",
     "prettier": "^3.1.1",
+    "proxy-agent": "^6.3.1",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
+    "undici": "^6.2.1",
     "vitest": "^1.1.0"
   },
   "packageManager": "pnpm@8.12.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,18 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@types/node':
+    specifier: ^20.10.5
+    version: 20.10.5
   '@vitest/coverage-v8':
     specifier: ^1.1.0
     version: 1.1.0(vitest@1.1.0)
   abort-controller:
     specifier: ^3.0.0
     version: 3.0.0
+  agent-base:
+    specifier: ^7.1.0
+    version: 7.1.0
   changelogen:
     specifier: ^0.5.5
     version: 0.5.5
@@ -20,21 +26,33 @@ devDependencies:
   eslint-config-unjs:
     specifier: ^0.2.1
     version: 0.2.1(eslint@8.56.0)(typescript@5.3.3)
+  http-proxy-agent:
+    specifier: ^7.0.0
+    version: 7.0.0
+  https-proxy-agent:
+    specifier: ^7.0.2
+    version: 7.0.2
   node-fetch:
     specifier: ^3.3.2
     version: 3.3.2
   prettier:
     specifier: ^3.1.1
     version: 3.1.1
+  proxy-agent:
+    specifier: ^6.3.1
+    version: 6.3.1
   typescript:
     specifier: ^5.3.3
     version: 5.3.3
   unbuild:
     specifier: ^2.0.0
     version: 2.0.0(typescript@5.3.3)
+  undici:
+    specifier: ^6.2.1
+    version: 6.2.1
   vitest:
     specifier: ^1.1.0
-    version: 1.1.0
+    version: 1.1.0(@types/node@20.10.5)
 
 packages:
 
@@ -496,6 +514,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@fastify/busboy@2.1.0:
+    resolution: {integrity: sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==}
+    engines: {node: '>=14'}
+    dev: true
+
   /@humanwhocodes/config-array@0.11.13:
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
@@ -778,6 +801,10 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
+  /@tootallnate/quickjs-emscripten@0.23.0:
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+    dev: true
+
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -797,6 +824,12 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/node@20.10.5:
+    resolution: {integrity: sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/normalize-package-data@2.4.4:
@@ -963,7 +996,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.1.0
+      vitest: 1.1.0(@types/node@20.10.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1158,6 +1191,13 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
+  /ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+    dependencies:
+      tslib: 2.6.2
+    dev: true
+
   /autoprefixer@10.4.16(postcss@8.4.32):
     resolution: {integrity: sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1181,6 +1221,11 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
+
+  /basic-ftp@5.0.4:
+    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
+    engines: {node: '>=10.0.0'}
     dev: true
 
   /big-integer@1.6.52:
@@ -1587,6 +1632,11 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
+  /data-uri-to-buffer@6.0.1:
+    resolution: {integrity: sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==}
+    engines: {node: '>= 14'}
+    dev: true
+
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -1669,6 +1719,15 @@ packages:
 
   /defu@6.1.3:
     resolution: {integrity: sha512-Vy2wmG3NTkmHNg/kzpuvHhkqeIx3ODWqasgCRbKtbXEN0G+HpEEv9BtJLp7ZG1CZloFaC41Ah3ZFbq7aqCqMeQ==}
+    dev: true
+
+  /degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
     dev: true
 
   /destr@2.0.2:
@@ -1869,6 +1928,18 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
     dev: true
 
   /eslint-compat-utils@0.1.2(eslint@8.56.0):
@@ -2206,6 +2277,12 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
+  /esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+    dev: true
+
   /esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
@@ -2400,6 +2477,15 @@ packages:
       universalify: 2.0.1
     dev: true
 
+  /fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+    dev: true
+
   /fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
@@ -2477,6 +2563,18 @@ packages:
     resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
     dependencies:
       resolve-pkg-maps: 1.0.0
+    dev: true
+
+  /get-uri@6.0.2:
+    resolution: {integrity: sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==}
+    engines: {node: '>= 14'}
+    dependencies:
+      basic-ftp: 5.0.4
+      data-uri-to-buffer: 6.0.1
+      debug: 4.3.4
+      fs-extra: 8.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /giget@1.1.3:
@@ -2643,6 +2741,16 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
+  /http-proxy-agent@7.0.0:
+    resolution: {integrity: sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /https-proxy-agent@7.0.2:
     resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
     engines: {node: '>= 14'}
@@ -2709,6 +2817,14 @@ packages:
       get-intrinsic: 1.2.2
       hasown: 2.0.0
       side-channel: 1.0.4
+    dev: true
+
+  /ip@1.1.8:
+    resolution: {integrity: sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==}
+    dev: true
+
+  /ip@2.0.0:
+    resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
     dev: true
 
   /is-array-buffer@3.0.2:
@@ -2999,6 +3115,12 @@ packages:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
     dev: true
 
+  /jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    dev: true
+
   /jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
     dependencies:
@@ -3085,6 +3207,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+    dev: true
+
+  /lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
     dev: true
 
   /magic-string@0.30.5:
@@ -3254,6 +3381,11 @@ packages:
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
+  /netmask@2.0.2:
+    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
+    engines: {node: '>= 0.4.0'}
     dev: true
 
   /node-domexception@1.0.0:
@@ -3455,6 +3587,31 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+    dev: true
+
+  /pac-proxy-agent@7.0.1:
+    resolution: {integrity: sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==}
+    engines: {node: '>= 14'}
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.0
+      debug: 4.3.4
+      get-uri: 6.0.2
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
+      pac-resolver: 7.0.0
+      socks-proxy-agent: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /pac-resolver@7.0.0:
+    resolution: {integrity: sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      degenerator: 5.0.1
+      ip: 1.1.8
+      netmask: 2.0.2
     dev: true
 
   /parent-module@1.0.1:
@@ -3875,6 +4032,26 @@ packages:
       react-is: 18.2.0
     dev: true
 
+  /proxy-agent@6.3.1:
+    resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+      http-proxy-agent: 7.0.0
+      https-proxy-agent: 7.0.2
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.0.1
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: true
+
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4142,6 +4319,30 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
+  /smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+    dev: true
+
+  /socks-proxy-agent@8.0.2:
+    resolution: {integrity: sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+      socks: 2.7.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /socks@2.7.1:
+    resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
+    engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
+    dependencies:
+      ip: 2.0.0
+      smart-buffer: 4.2.0
+    dev: true
+
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
@@ -4366,6 +4567,10 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: true
+
   /tsutils@3.21.0(typescript@5.3.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -4499,6 +4704,22 @@ packages:
       - supports-color
     dev: true
 
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
+  /undici@6.2.1:
+    resolution: {integrity: sha512-7Wa9thEM6/LMnnKtxJHlc8SrTlDmxqJecgz1iy8KlsN0/iskQXOQCuPkrZLXbElPaSw5slFFyKIKXyJ3UtbApw==}
+    engines: {node: '>=18.0'}
+    dependencies:
+      '@fastify/busboy': 2.1.0
+    dev: true
+
+  /universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -4561,7 +4782,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@1.1.0:
+  /vite-node@1.1.0(@types/node@20.10.5):
     resolution: {integrity: sha512-jV48DDUxGLEBdHCQvxL1mEh7+naVy+nhUUUaPAZLd3FJgXuxQiewHcfeZebbJ6onDqNGkP4r3MhQ342PRlG81Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -4570,7 +4791,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.0.10
+      vite: 5.0.10(@types/node@20.10.5)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4582,7 +4803,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.0.10:
+  /vite@5.0.10(@types/node@20.10.5):
     resolution: {integrity: sha512-2P8J7WWgmc355HUMlFrwofacvr98DAjoE52BfdbwQtyLH06XKwaL/FMnmKM2crF0iX4MpmMKoDlNCB1ok7zHCw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -4610,6 +4831,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.10.5
       esbuild: 0.19.10
       postcss: 8.4.32
       rollup: 4.9.1
@@ -4617,7 +4839,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.1.0:
+  /vitest@1.1.0(@types/node@20.10.5):
     resolution: {integrity: sha512-oDFiCrw7dd3Jf06HoMtSRARivvyjHJaTxikFxuqJjO76U436PqlVw1uLn7a8OSPrhSfMGVaRakKpA2lePdw79A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -4642,6 +4864,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
+      '@types/node': 20.10.5
       '@vitest/expect': 1.1.0
       '@vitest/runner': 1.1.0
       '@vitest/snapshot': 1.1.0
@@ -4660,8 +4883,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.1
-      vite: 5.0.10
-      vite-node: 1.1.0
+      vite: 5.0.10(@types/node@20.10.5)
+      vite-node: 1.1.0(@types/node@20.10.5)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/src/proxy-stub.ts
+++ b/src/proxy-stub.ts
@@ -1,0 +1,6 @@
+export function createProxy() {
+  return {
+    agent: undefined,
+    dispatcher: undefined,
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,118 @@
+import * as http from "node:http";
+import * as https from "node:https";
+import { URL } from "node:url";
+import { ProxyAgent as UndiciProxyAgent } from "undici";
+import { Agent, AgentConnectOpts } from "agent-base";
+import { HttpProxyAgent } from "http-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
+
+export function createProxy(opts: { url?: string } = {}) {
+  const uri = opts.url || process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+
+  if (!uri) {
+    return {
+      agent: undefined,
+      dispatcher: undefined,
+    };
+  }
+
+  const nodeAgent = new NodeProxyAgent({ uri });
+
+  // https://undici.nodejs.org/#/docs/api/ProxyAgent
+  const undiciAgent = new UndiciProxyAgent({ uri });
+
+  return {
+    agent: nodeAgent,
+    dispatcher: undiciAgent,
+  };
+}
+
+export function debug(...args: any[]) {
+  if (process.env.debug) {
+    debug("[node-fetch-native] [proxy]", ...args);
+  }
+}
+
+// ----------------------------------------------
+// HTTP Agent
+// ----------------------------------------------
+
+// https://github.com/TooTallNate/proxy-agents/tree/main/packages/proxy-agent
+
+const PROTOCOLS = ["http", "https"] as const;
+
+type ValidProtocol = (typeof PROTOCOLS)[number];
+type AgentConstructor = new (...args: never[]) => Agent;
+
+const proxies: {
+  [P in ValidProtocol]: [AgentConstructor, AgentConstructor];
+} = {
+  http: [HttpProxyAgent, HttpsProxyAgent],
+  https: [HttpProxyAgent, HttpsProxyAgent],
+};
+
+function isValidProtocol(v: string): v is ValidProtocol {
+  return (PROTOCOLS as readonly string[]).includes(v);
+}
+
+export class NodeProxyAgent extends Agent {
+  cache: Map<string, Agent> = new Map();
+
+  httpAgent: http.Agent;
+  httpsAgent: http.Agent;
+
+  constructor(private proxyOptions: { uri: string }) {
+    super({});
+    debug("Creating new ProxyAgent instance: %o", proxyOptions);
+    this.httpAgent = new http.Agent({});
+    this.httpsAgent = new https.Agent({});
+  }
+
+  connect(req: http.ClientRequest, opts: AgentConnectOpts): http.Agent {
+    const isWebSocket = req.getHeader("upgrade") === "websocket";
+
+    // prettier-ignore
+    const protocol = opts.secureEndpoint
+      ? (isWebSocket ? "wss:" : "https:")
+      : (isWebSocket ? "ws:" : "http:");
+
+    const host = req.getHeader("host");
+    const url = new URL(req.path, `${protocol}//${host}`).href;
+    const proxy = this.proxyOptions.uri;
+
+    if (!proxy) {
+      debug("Proxy not enabled for URL: %o", url);
+      return opts.secureEndpoint ? this.httpsAgent : this.httpAgent;
+    }
+
+    debug("Request URL: %o", url);
+    debug("Proxy URL: %o", proxy);
+
+    // Attempt to get a cached `http.Agent` instance first
+    const cacheKey = `${protocol}+${proxy}`;
+    let agent = this.cache.get(cacheKey);
+    if (agent) {
+      debug("Cache hit for proxy URL: %o", proxy);
+    } else {
+      const proxyUrl = new URL(proxy);
+      const proxyProto = proxyUrl.protocol.replace(":", "");
+      if (!isValidProtocol(proxyProto)) {
+        throw new Error(`Unsupported protocol for proxy URL: ${proxy}`);
+      }
+      const Ctor =
+        proxies[proxyProto][opts.secureEndpoint || isWebSocket ? 1 : 0];
+      // @ts-expect-error meh…
+      agent = new Ctor(proxy, this.connectOpts);
+      this.cache.set(cacheKey, agent);
+    }
+
+    return agent;
+  }
+
+  destroy(): void {
+    for (const agent of this.cache.values()) {
+      agent.destroy();
+    }
+    super.destroy();
+  }
+}

--- a/test/proxy.mjs
+++ b/test/proxy.mjs
@@ -1,0 +1,13 @@
+import { fetch } from "node-fetch-native"; // or use global fetch
+import { createProxy } from "node-fetch-native/proxy";
+
+process.env.HTTPS_PROXY = "http://localhost:9080";
+process.env.DEBUG = "true";
+
+const proxy = createProxy();
+
+const res = await fetch("https://icanhazip.com", {
+  ...proxy,
+});
+
+console.log(await res.text());


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds HTTP proxy support to node-fetch-native using a new subpath export.

Sadly it adds ~500KB to the bundle but since Node.js is not going to soon make any attempt for built in HTTP proxy support and installing deps for all runtime versions of node takes much more without bundling.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
