### PR TITLE
build: remove non existing `node.import` condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,10 +81,6 @@
     },
     "./proxy": {
       "node": {
-        "import": {
-          "types": "./lib/proxy.d.ts",
-          "default": "./dist/proxy.cjs"
-        },
         "require": {
           "types": "./lib/proxy.d.ts",
           "default": "./dist/proxy.cjs"


### PR DESCRIPTION
### 🔗 Linked issue
#114 

### ❓ Type of change
Remove the node.import statement from package.json since proxy is only provided in commonJS format, resulting in build errors with Bun.

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since the proxy is not included in a esm format, it results in the bundlers (Bun in the case of the issue), to throw an error about a missing export.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
