### PR TITLE
fix: improve `DISABLE_NODE_FETCH_NATIVE_WARN` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ You have two ways to do this:
 - Set the `FORCE_NODE_FETCH` environment variable before starting the application.
 - Import from `node-fetch-native/node`
 
+## Disable runtime check
+
+Once the `node-fetch-native/node` module is loaded, it pushes a log warning if the current runtime differs from the Node.js. Set the `DISABLE_NODE_FETCH_NATIVE_WARN` environment variable to turn this check off.
+
 ## Polyfill support
 
 Using the polyfill method, we can ensure global fetch is available in the environment and all files. Natives are always preferred.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,14 +21,7 @@ export {
 
 const _forceNodeFetch = !!globalThis.process?.env?.FORCE_NODE_FETCH;
 
-function _getFetch() {
-  if (!_forceNodeFetch && globalThis.fetch) {
-    return globalThis.fetch;
-  }
-  return _fetch;
-}
-
-export const fetch = _getFetch();
+export const fetch = (!_forceNodeFetch && globalThis.fetch) || _fetch;
 export default fetch;
 
 export const Blob = (!_forceNodeFetch && globalThis.Blob) || _Blob;

--- a/src/node.ts
+++ b/src/node.ts
@@ -21,7 +21,7 @@ checkNodeEnvironment();
 function checkNodeEnvironment() {
   if (
     !globalThis.process?.versions?.node &&
-    !globalThis.process?.env.DISABLE_NODE_FETCH_NATIVE_WARN
+    !globalThis.process?.env?.DISABLE_NODE_FETCH_NATIVE_WARN
   ) {
     console.warn(
       "[node-fetch-native] Node.js compatible build of `node-fetch-native` is being used in a non-Node.js environment. Please make sure you are using proper export conditions or report this issue to https://github.com/unjs/node-fetch-native. You can set `process.env.DISABLE_NODE_FETCH_NATIVE_WARN` to disable this warning.",


### PR DESCRIPTION
This PR:
* Adds a description of the `env.DISABLE_NODE_FETCH_NATIVE_WARN`
* Aligns index vars initialization
