### PR TITLE
build: build with `es2020` target

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -8,6 +8,7 @@ export default defineBuildConfig({
     emitCJS: true,
     inlineDependencies: true,
     esbuild: {
+      target: 'es2020',
       minify: true,
       minifyIdentifiers: false,
       minifySyntax: false,


### PR DESCRIPTION
This PR:

- Try to solve the issue https://github.com/unjs/node-fetch-native/issues/136.

The issue is caused by the default target of esbuild, which being changed from 'es2020' to 'esnext' via pr https://github.com/unjs/unbuild/pull/335/files

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
