### PR TITLE
fix(proxy): strip port from host when checking noProxy bypass

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,8 +22,18 @@ function bypassProxy(host: string, noProxy: string[]) {
   if (!noProxy) {
     return false;
   }
+  // Strip port from host if present (e.g., "example.com:8080" -> "example.com")
+  // Also handles IPv6 brackets (e.g., "[::1]:8080" -> "::1")
+  let hostname = host;
+  if (host.startsWith("[") && host.includes("]")) {
+    // IPv6: [::1] or [::1]:port
+    hostname = host.slice(1, host.indexOf("]"));
+  } else if (host.includes(":")) {
+    // IPv4 or hostname with port
+    hostname = host.split(":")[0];
+  }
   for (const _host of noProxy) {
-    if (_host === host || (_host[0] === "." && host.endsWith(_host.slice(1)))) {
+    if (_host === hostname || (_host[0] === "." && hostname.endsWith(_host.slice(1)))) {
       return true;
     }
   }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #125

### 📝 Description

The `bypassProxy` function previously compared the raw `host` header (which may include a port like `10.10.10.10:8001`) against `noProxy` entries (which don't include ports like `10.10.10.10`). This caused requests to hosts with explicit ports to incorrectly use the proxy even when the host was listed in `no_proxy`.

**Example of the bug:**
```
http_proxy = 10.0.0.1:3128
no_proxy = 10.10.10.10
fetch('http://10.10.10.10:8001/healthz')  // incorrectly uses proxy!
```

### 🧪 Fix

Now strips port from host before comparison in `bypassProxy`, handling:
- **IPv4 with port:** `host:port` → `host`
- **IPv6 with brackets:** `[::1]:port` → `::1`

Note: `UndiciProxyAgent.dispatch()` already uses `new URL(options.origin).hostname` which strips ports, so only `NodeProxyAgent.connect()` (which uses `req.getHeader("host")`) was affected.

### Testing

The fix follows the standard URL parsing behavior: `new URL("http://host:port").hostname` returns just `host`. This ensures consistency between the two proxy agent implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced proxy bypass matching to properly handle hostnames containing port numbers and IPv6 addresses. The system now normalizes hostnames before comparing against bypass rules, ensuring consistent and accurate bypass decisions regardless of port or address format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->